### PR TITLE
refactor(cli/flags): define `flags` on each command

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -17,7 +17,7 @@ import (
 func NewCmd(app *application.App) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "add",
-		Short: "add bookmark",
+		Short: "add a bookmark",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			d, cancel, err := cmdutil.SetupDeps(cmd, &args)
 			if err != nil {
@@ -46,9 +46,8 @@ func NewCmd(app *application.App) *cobra.Command {
 			return nil
 		},
 	}
+	c.Flags().SortFlags = false
 	c.Flags().StringVar(&app.Flags.Title, "title", "", "bookmark title")
 	c.Flags().StringVar(&app.Flags.TagsStr, "tags", "", "bookmark tags")
-	cmdutil.HideFlag(c, "help")
-
 	return c
 }

--- a/cmd/archive/fetcher.go
+++ b/cmd/archive/fetcher.go
@@ -51,6 +51,8 @@ func newLookupCmd(app *application.App) *cobra.Command {
 	f.BoolVarP(&app.Flags.Update, "latest", "l", false, "fetches lasts snapshot from Wayback Machine")
 	f.IntVarP(&app.Flags.Limit, "limit", "L", 0, "limit the number of snapshots returned")
 	f.IntVarP(&app.Flags.Year, "year", "Y", 0, "fetches the last N snapshots from a specific year")
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 
 	return c
 }

--- a/cmd/archive/snapshot.go
+++ b/cmd/archive/snapshot.go
@@ -50,7 +50,9 @@ func newOpenCmd(app *application.App) *cobra.Command {
 			return cmdutil.Execute(cmd, args, setupMenu(app), handler.Open, onlySnapshots)
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }
 

--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -27,8 +27,9 @@ func NewCmd(app *application.App) *cobra.Command {
 			return cmdutil.Execute(cmd, args, m, func(d *deps.Deps, bs []*bookmark.Bookmark) error {
 				const maxGoroutines = 15
 
-				s := fmt.Sprintf("checking status of %d bookmarks", len(bs))
-				if err := d.Console().ConfirmLimit(len(bs), maxGoroutines, s, d.App.Flags.Force); err != nil {
+				p := d.Console().Palette()
+				q := fmt.Sprintf("checking %s of %d bookmarks", p.BrightGreen.Wrap("status", p.Bold), len(bs))
+				if err := d.Console().ConfirmLimit(len(bs), maxGoroutines, q, d.App.Flags.Force); err != nil {
 					return sys.ErrActionAborted
 				}
 
@@ -52,6 +53,9 @@ func NewCmd(app *application.App) *cobra.Command {
 		},
 	}
 
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	c.AddCommand(newUpdateCmd(app))
 
 	return c
@@ -85,7 +89,9 @@ func newUpdateCmd(app *application.App) *cobra.Command {
 			})
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }
 

--- a/cmd/clean/clean.go
+++ b/cmd/clean/clean.go
@@ -39,7 +39,8 @@ func NewCmd(app *application.App) *cobra.Command {
 			return cmdutil.Execute(cmd, args, m, handler.ParamsURL, WithURLParametersOnly)
 		},
 	}
-
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }
 

--- a/cmd/cmdutil/cmdutil.go
+++ b/cmd/cmdutil/cmdutil.go
@@ -2,10 +2,8 @@ package cmdutil
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/mateconpizza/gm/internal/application"
 	"github.com/mateconpizza/gm/internal/deps"
@@ -26,37 +24,6 @@ type (
 	// before they are passed to an action or presented in a menu.
 	Filter func([]*bookmark.Bookmark) []*bookmark.Bookmark
 )
-
-const UsageTemplate = `usage: {{if .Runnable}}{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}} [command]{{end}}
-{{- if gt (len .Aliases) 0}}
-
-aliases: {{.NameAndAliases}}
-{{- end}}
-{{- if .HasExample}}
-
-examples:
-{{.Example}}
-{{- end}}
-{{- if gt (len .Commands) 0}}
-
-commands:
-{{- range .Commands}}
-  {{- if or .IsAvailableCommand (eq .Name "help")}}
-  {{rpad .Name .NamePadding}} {{.Short}}
-  {{- end}}
-{{- end}}
-{{- end}}
-{{- if hasFlags .}}
-
-flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
-{{- end}}
-{{- if .HasAvailableInheritedFlags}}
-
-global:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
-{{- end}}
-`
 
 // SetupDeps inicializa la config, db y app para los subcommands.
 func SetupDeps(cmd *cobra.Command, args *[]string) (*deps.Deps, func(), error) {
@@ -131,44 +98,4 @@ func Execute(
 	}
 
 	return action(d, bs)
-}
-
-func FlagOutput(c *cobra.Command, app *application.App, supportedOutput []string) {
-	c.Flags().StringVarP(&app.Flags.Output, "output", "o", "", "output format: "+strings.Join(supportedOutput, ", "))
-
-	_ = c.RegisterFlagCompletionFunc("output",
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return supportedOutput, cobra.ShellCompDirectiveNoFileComp
-		})
-}
-
-func FlagFields(c *cobra.Command, app *application.App, fields string) {
-	c.Flags().StringVarP(&app.Flags.Field, "fields", "f", "", "select fields: "+fields)
-}
-
-func HasFlags(cmd *cobra.Command) bool {
-	hasVisible := false
-	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
-		if !f.Hidden {
-			hasVisible = true
-		}
-	})
-	return hasVisible
-}
-
-func HideFlag(c *cobra.Command, names ...string) {
-	for _, name := range names {
-		if f := c.Flags().Lookup(name); f != nil {
-			f.Hidden = true
-			continue
-		}
-		if f := c.PersistentFlags().Lookup(name); f != nil {
-			f.Hidden = true
-		}
-	}
-}
-
-func FlagDBRequired(c *cobra.Command, app *application.App) {
-	c.Flags().StringVar(&app.DBName, "db", application.MainDBName, "database name")
-	_ = c.MarkFlagRequired("db")
 }

--- a/cmd/cmdutil/flags.go
+++ b/cmd/cmdutil/flags.go
@@ -1,0 +1,110 @@
+package cmdutil
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/mateconpizza/gm/internal/application"
+)
+
+var GlobalFlags = []string{"fields", "head", "menu", "output", "sort", "tag", "tail"}
+
+const UsageTemplate = `usage: {{if .Runnable}}{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}} [command]{{end}}
+{{- if gt (len .Aliases) 0}}
+
+aliases: {{.NameAndAliases}}
+{{- end}}
+{{- if .HasExample}}
+
+examples:
+{{.Example}}
+{{- end}}
+{{- if gt (len .Commands) 0}}
+
+commands:
+{{- range .Commands}}
+  {{- if or .IsAvailableCommand (eq .Name "help")}}
+  {{rpad .Name .NamePadding}} {{.Short}}
+  {{- end}}
+{{- end}}
+{{- end}}
+{{- if hasFlags .}}
+
+flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{- end}}
+{{- if .HasAvailableInheritedFlags}}
+
+global:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{- end}}
+`
+
+func FlagOutput(c *cobra.Command, app *application.App, supportedOutput []string) {
+	c.Flags().StringVarP(&app.Flags.Output, "output", "o", "", "output format: "+strings.Join(supportedOutput, ", "))
+}
+
+func FlagFields(c *cobra.Command, app *application.App, fields string) {
+	c.Flags().StringVarP(&app.Flags.Field, "fields", "f", "", "select fields: "+fields)
+}
+
+func FlagDBRequired(c *cobra.Command, app *application.App) {
+	c.Flags().StringVar(&app.DBName, "db", application.MainDBName, "database name")
+	_ = c.MarkFlagRequired("db")
+}
+
+func FlagsFilter(c *cobra.Command, app *application.App) {
+	c.Flags().StringSliceVarP(&app.Flags.Tags, "tag", "t", nil, "filter by tag(s)")
+	c.Flags().IntVarP(&app.Flags.Head, "head", "H", 0, "limit to first N bookmarks")
+	c.Flags().IntVarP(&app.Flags.Tail, "tail", "T", 0, "limit to last N bookmarks")
+}
+
+func FlagMenu(c *cobra.Command, app *application.App) {
+	c.Flags().BoolVarP(&app.Flags.Menu, "menu", "m", false, "select interactively")
+}
+
+func FlagSort(c *cobra.Command, app *application.App, sortSupported []string) {
+	c.Flags().StringVarP(&app.Flags.Sort, "sort", "s", "", "sort by: "+strings.Join(sortSupported, ", "))
+}
+
+func HasFlags(cmd *cobra.Command) bool {
+	hasVisible := false
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if !f.Hidden {
+			hasVisible = true
+		}
+	})
+	return hasVisible
+}
+
+func HideFlag(c *cobra.Command, names ...string) {
+	for _, name := range names {
+		// search local flags
+		if f := c.Flags().Lookup(name); f != nil {
+			f.Hidden = true
+			continue
+		}
+		// search in flags inherited from the parent
+		if f := c.InheritedFlags().Lookup(name); f != nil {
+			f.Hidden = true
+			continue
+		}
+		// not found?: register as local and hide
+		c.Flags().Bool(name, false, "")
+		_ = c.Flags().MarkHidden(name)
+	}
+}
+
+// DisableFlagSorting recursively disables flag sorting on a command
+// and all its subcommands.
+func DisableFlagSorting(c *cobra.Command) *cobra.Command {
+	c.Flags().SortFlags = false
+	c.InheritedFlags().SortFlags = false
+	c.PersistentFlags().SortFlags = false
+	for _, sub := range c.Commands() {
+		DisableFlagSorting(sub)
+	}
+	return c
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -24,7 +24,7 @@ func NewCmd(app *application.App) *cobra.Command {
 		Aliases: []string{"cfg", "conf"},
 		Short:   "configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if app.Flags.JSON {
+			if app.Flags.Output == "json" || app.Flags.Output == "j" {
 				return newJSONCmd(app).RunE(cmd, args)
 			}
 
@@ -32,23 +32,25 @@ func NewCmd(app *application.App) *cobra.Command {
 				return newEditCmd(app).RunE(cmd, args)
 			}
 
+			if app.Flags.List {
+				return newShowPathCmd(app).RunE(cmd, args)
+			}
+
 			return cmd.Help()
 		},
 	}
-
-	c.Flags().StringVarP(&app.Flags.ColorStr, "color", "c", "always", "")
-	c.Flags().StringVar(&app.DBName, "db", application.MainDBName, "database name")
-	c.Flags().BoolVarP(&app.Flags.JSON, "json", "j", false, "output in JSON format")
 	c.Flags().BoolVarP(&app.Flags.Edit, "edit", "e", false, "edit with text editor")
-	cmdutil.HideFlag(c, "help", "color", "db")
+	c.Flags().BoolVar(&app.Flags.List, "path", false, "print config file location")
+	cmdutil.FlagOutput(c, app, []string{"json"})
+	cmdutil.HideFlag(c, "color", "db", "menu", "head", "tail", "fields", "sort", "tag")
 
-	c.AddCommand(newCreateCmd(app), newEditCmd(app), newShowPathCmd(app))
+	c.AddCommand(newCreateCmd(app))
 
 	return c
 }
 
 func newCreateCmd(app *application.App) *cobra.Command {
-	return &cobra.Command{
+	c := &cobra.Command{
 		Use:   "create",
 		Short: "create configuration file",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -59,6 +61,8 @@ func newCreateCmd(app *application.App) *cobra.Command {
 			return createConfig(c, app)
 		},
 	}
+	cmdutil.HideFlag(c, "db")
+	return c
 }
 
 func newEditCmd(app *application.App) *cobra.Command {

--- a/cmd/database/database.go
+++ b/cmd/database/database.go
@@ -58,9 +58,7 @@ func NewCmd(app *application.App) *cobra.Command {
 	f.SortFlags = false
 	f.BoolVarP(&app.Flags.Vacuum, "vacuum", "X", false, "rebuilds the database file")
 	f.BoolVarP(&app.Flags.Reorder, "reorder", "R", false, "reorder IDs")
-
-	c.AddCommand(
-		createCmd, newDatabaseRemoveCmd(app), newListCmd(app),
+	c.AddCommand(newAddCmd(app), newDatabaseRemoveCmd(app), newListCmd(app),
 		newInfoCmd(app), newBackupCmd(app), newDropCmd(app),
 		newLockCmd(app), newUnlockCmd(app))
 
@@ -106,15 +104,20 @@ func newListCmd(_ *application.App) *cobra.Command {
 	return c
 }
 
-var createCmd = &cobra.Command{
-	Use:               "create",
-	Short:             "create a database",
-	Aliases:           []string{"add"},
-	Example:           `  gm db create -n myDb`,
-	Annotations:       cli.SkipDBCheck,
-	PersistentPreRunE: setup.InitCmd.PersistentPreRunE,
-	RunE:              setup.InitCmd.RunE,
-	PostRunE:          setup.InitCmd.PostRunE,
+func newAddCmd(app *application.App) *cobra.Command {
+	c := &cobra.Command{
+		Use:         "add",
+		Short:       "add a database",
+		Aliases:     []string{"create"},
+		Example:     `  gm db add --db myDb`,
+		Annotations: cli.SkipDBCheck,
+		RunE:        setup.InitCmd.RunE,
+		PostRunE:    setup.InitCmd.PostRunE,
+	}
+
+	cmdutil.FlagDBRequired(c, app)
+
+	return c
 }
 
 func newDropCmd(app *application.App) *cobra.Command {

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -35,15 +35,16 @@ func NewCmd(app *application.App) *cobra.Command {
 
 			var strategy editor.EditStrategy
 			strategy = editor.BookmarkStrategy{}
-			if app.Flags.JSON {
+			if app.Flags.Output == "json" || app.Flags.Output == "j" {
 				strategy = editor.JSONStrategy{}
 			}
 
 			return cmdutil.Execute(cmd, args, m, handler.Edit(strategy))
 		},
 	}
-
-	c.Flags().BoolVarP(&app.Flags.JSON, "json", "j", false, "edit bookmark as JSON")
-
+	cmdutil.FlagOutput(c, app, []string{"json"})
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }

--- a/cmd/git/git.go
+++ b/cmd/git/git.go
@@ -53,22 +53,9 @@ func NewCmd(app *application.App) *cobra.Command {
 			return gm.Exec(args...)
 		},
 	}
-
-	cmds := []*cobra.Command{
-		newInitRepoCmd(app),
-		newTrackerCmd(app),
-		newImportCmd(app),
-		newCloneCmd(app),
-		commitCmd,
-		newPushCmd(app),
-		newRawCmd(app),
-	}
-
-	for i := range cmds {
-		cmdutil.HideFlag(cmds[i], "help")
-	}
-	c.AddCommand(cmds...)
-	cmdutil.HideFlag(c, "help")
+	c.AddCommand(
+		newInitRepoCmd(app), newTrackerCmd(app), newImportCmd(app),
+		newCloneCmd(app), commitCmd, newPushCmd(app), newRawCmd(app))
 
 	return c
 }

--- a/cmd/io/in/in.go
+++ b/cmd/io/in/in.go
@@ -41,8 +41,6 @@ func NewCmd(app *application.App) *cobra.Command {
 		newFromBackupCmd(app),
 	)
 
-	cmdutil.HideFlag(c, "help")
-
 	return c
 }
 

--- a/cmd/io/out/out.go
+++ b/cmd/io/out/out.go
@@ -24,14 +24,14 @@ func NewCmd(app *application.App) *cobra.Command {
 		Aliases: []string{"ex"},
 		RunE:    cli.HookHelp,
 	}
-
 	cmds := []func(*application.App) *cobra.Command{newHTMLCmd, newJSONCmd, newCSVCmd}
 	for i := range cmds {
 		cmd := cmds[i](app)
-		cmdutil.HideFlag(cmd, "help")
+		cmdutil.FlagSort(cmd, app, handler.SortSupported)
+		cmdutil.FlagMenu(cmd, app)
+		cmdutil.FlagsFilter(cmd, app)
 		c.AddCommand(cmd)
 	}
-
 	return c
 }
 
@@ -46,7 +46,6 @@ func newHTMLCmd(app *application.App) *cobra.Command {
 			})
 		},
 	}
-
 	return c
 }
 
@@ -61,7 +60,6 @@ func newJSONCmd(app *application.App) *cobra.Command {
 			})
 		},
 	}
-
 	return c
 }
 
@@ -76,9 +74,7 @@ func newCSVCmd(app *application.App) *cobra.Command {
 			})
 		},
 	}
-
 	cmdutil.FlagFields(c, app, "all,"+wrapFields(bookmark.Fields(), ",", 50))
-
 	return c
 }
 

--- a/cmd/notes/notes.go
+++ b/cmd/notes/notes.go
@@ -48,12 +48,13 @@ func NewCmd(app *application.App) *cobra.Command {
 				}
 
 				return printer.Notes(d.Console(), bs)
-			}, OnlyNotes)
+			}, onlyNotes)
 		},
 	}
 
-	c.Flags().BoolVarP(&app.Flags.Edit, "edit", "e", false, "edit with text editor")
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	c.AddCommand(newEditNotesCmd(app))
 
 	return c
@@ -74,11 +75,13 @@ func newEditNotesCmd(app *application.App) *cobra.Command {
 			return cmdutil.Execute(cmd, args, m, handler.Edit(editor.NotesStrategy{}))
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }
 
-func OnlyNotes(bs []*bookmark.Bookmark) []*bookmark.Bookmark {
+func onlyNotes(bs []*bookmark.Bookmark) []*bookmark.Bookmark {
 	filtered := make([]*bookmark.Bookmark, 0, len(bs))
 	for i := range bs {
 		if bs[i].Notes == "" {

--- a/cmd/open/open.go
+++ b/cmd/open/open.go
@@ -16,8 +16,7 @@ func NewCmd(app *application.App) *cobra.Command {
 		Aliases: []string{"o"},
 		Short:   "open in browser",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p := "{+1}"
-			kb := menu.NewBindBuilder(app.Cmd, app.DBName).WithPlaceholder(p)
+			kb := menu.NewBindBuilder(app.Cmd, app.DBName).WithPlaceholder("{+1}")
 			m := handler.MenuSimple[bookmark.Bookmark](app,
 				menu.WithMultiSelection(),
 				menu.WithHeaderLabel(" open in browser "),
@@ -28,6 +27,8 @@ func NewCmd(app *application.App) *cobra.Command {
 			return cmdutil.Execute(cmd, args, m, handler.Open)
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }

--- a/cmd/qrcmd/qrcmd.go
+++ b/cmd/qrcmd/qrcmd.go
@@ -28,16 +28,12 @@ func NewCmd(app *application.App) *cobra.Command {
 		Aliases: []string{"q"},
 		Short:   "generate QR",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m := handler.MenuSimple[bookmark.Bookmark](app,
-				menu.WithMultiSelection(),
-				menu.WithHeader("select record/s"),
-				menu.WithHeaderLabel(" QR-code "),
-				menu.WithPreview(app.PreviewCmd("{1}")),
-			)
-			return cmdutil.Execute(cmd, args, m, handler.QR)
+			return cmdutil.Execute(cmd, args, setupMenu(app), handler.QR)
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	c.AddCommand(newOpenCmd(app), newGenQR(app))
 
 	return c
@@ -49,14 +45,7 @@ func newOpenCmd(app *application.App) *cobra.Command {
 		Aliases: []string{"q"},
 		Short:   "open QR-code image in default viewer",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			m := handler.MenuSimple[bookmark.Bookmark](app,
-				menu.WithMultiSelection(),
-				menu.WithHeader("select record/s"),
-				menu.WithHeaderLabel(" QR-code "),
-				menu.WithPreview(app.PreviewCmd(app.DBName, "{1}")),
-			)
-
-			return cmdutil.Execute(cmd, args, m, func(d *deps.Deps, bs []*bookmark.Bookmark) error {
+			return cmdutil.Execute(cmd, args, setupMenu(app), func(d *deps.Deps, bs []*bookmark.Bookmark) error {
 				for i := range bs {
 					b := bs[i]
 					qrcode := qr.New(b.URL)
@@ -67,12 +56,13 @@ func newOpenCmd(app *application.App) *cobra.Command {
 						return err
 					}
 				}
-
 				return nil
 			})
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }
 
@@ -106,9 +96,17 @@ func newGenQR(app *application.App) *cobra.Command {
 			return nil
 		},
 	}
-
 	c.Flags().StringVarP(&app.Flags.Path, "output", "o", "",
-		fmt.Sprintf("write QR image to file [%s]", strings.Join(validFormats, "|")))
+		"write QR image to file: "+strings.Join(validFormats, ", "))
 
 	return c
+}
+
+func setupMenu(app *application.App) *menu.Menu[bookmark.Bookmark] {
+	return handler.MenuSimple[bookmark.Bookmark](app,
+		menu.WithMultiSelection(),
+		menu.WithHeader("select record/s"),
+		menu.WithHeaderLabel(" QR-code "),
+		menu.WithPreview(app.PreviewCmd(app.DBName, "{1}")),
+	)
 }

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -111,53 +111,37 @@ func registerCleanups(_ *application.App) {
 }
 
 func registerRootFlags(c *cobra.Command, app *application.App) {
-	local := c.Flags()
-	global := c.PersistentFlags()
-	global.SortFlags = false
+	c.Flags().SortFlags = false
 
-	// Register common filtering flags (tags, head, tail)
-	global.StringSliceVarP(&app.Flags.Tags, "tag", "t", nil, "filter by tag(s)")
-
-	// Limit results (head/tail semantics)
-	global.IntVarP(&app.Flags.Head, "head", "H", 0, "limit to first N bookmarks")
-	global.IntVarP(&app.Flags.Tail, "tail", "T", 0, "limit to last N bookmarks")
-
-	// Interactive mode (e.g. TUI or prompt-based selection)
-	global.BoolVarP(&app.Flags.Menu, "menu", "m", false, "select interactively")
-
-	// Output formatting (e.g. json, csv, table, etc.)
+	// local
+	// limit results (head/tail semantics)
+	cmdutil.FlagsFilter(c, app)
+	// interactive mode
+	cmdutil.FlagMenu(c, app)
+	// output formatting
 	cmdutil.FlagOutput(c, app, formatter.ValidFormats())
-
-	// Field selection for output projection
+	// sorting strategy (domain-specific ordering options)
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	// field selection for output projection
 	fields := []string{"id", "url", "title", "tags", "desc"}
-	global.StringVarP(&app.Flags.Field, "fields", "f", "", "select fields: "+strings.Join(fields, ", "))
+	cmdutil.FlagFields(c, app, strings.Join(fields, ", "))
 
-	// Sorting strategy (domain-specific ordering options)
-	global.StringVarP(&app.Flags.Sort, "sort", "s", "", "sort by: "+strings.Join(handler.SortSupported, ", "))
+	// global
+	g := c.PersistentFlags()
+	// database selection
+	g.StringVar(&app.DBName, "db", application.MainDBName, "database name")
+	// output colorization policy
+	g.StringVar(&app.Flags.ColorStr, "color", "always", "colorize output: always, never")
+	// non-interactive confirmation
+	g.BoolVarP(&app.Flags.Yes, "yes", "y", false, "assume yes")
+	// force execution even if safeguards would prevent it
+	g.BoolVar(&app.Flags.Force, "force", false, "force action")
+	// verbosity level
+	g.CountVarP(&app.Flags.Verbose, "verbose", "v", "increase verbosity (-v, -vv, -vvv)")
 
-	// Verbosity level
-	global.CountVarP(&app.Flags.Verbose, "verbose", "v", "increase verbosity (-v, -vv, -vvv)")
-
-	// Non-interactive confirmation
-	global.BoolVarP(&app.Flags.Yes, "yes", "y", false, "assume yes")
-
-	// Output colorization policy
-	global.StringVar(&app.Flags.ColorStr, "color", "always", "colorize output: always, never")
-
-	// Force execution even if safeguards would prevent it
-	global.BoolVar(&app.Flags.Force, "force", false, "force action")
-
-	// Database selection
-	global.StringVar(&app.DBName, "db", application.MainDBName, "database name")
-
-	// Override default help flag to hide it
-	global.Bool("help", false, "")
-	_ = global.MarkHidden("help")
-
-	// Hidden/internal flag
-	global.StringVar(&app.Flags.Preview, "preview", "", "")
-	_ = global.MarkHidden("preview")
-
-	// Version flag
-	local.BoolVarP(&app.Flags.Version, "version", "V", false, "version for "+app.Cmd)
+	// hidden
+	g.Bool("help", false, "")
+	_ = g.MarkHidden("help")
+	g.StringVar(&app.Flags.Preview, "preview", "", "")
+	_ = g.MarkHidden("preview")
 }

--- a/cmd/rm/rm.go
+++ b/cmd/rm/rm.go
@@ -27,6 +27,8 @@ func NewCmd(app *application.App) *cobra.Command {
 			return cmdutil.Execute(cmd, args, m, handler.Remove)
 		},
 	}
-
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }

--- a/cmd/yank/yank.go
+++ b/cmd/yank/yank.go
@@ -49,6 +49,9 @@ func NewCmd(app *application.App) *cobra.Command {
 			})
 		},
 	}
-
+	cmdutil.FlagOutput(c, app, []string{"json"})
+	cmdutil.FlagSort(c, app, handler.SortSupported)
+	cmdutil.FlagMenu(c, app)
+	cmdutil.FlagsFilter(c, app)
 	return c
 }

--- a/internal/handler/selection.go
+++ b/internal/handler/selection.go
@@ -122,7 +122,7 @@ func selectItem(d *deps.Deps, fs []string, header string) (string, error) {
 		menu.WithOutputColor(d.App.Flags.Color),
 		menu.WithConfig(d.App.Menu),
 		menu.WithHeader(header),
-		menu.WithPreview(d.App.PreviewCmd(d.App.DBName, "{1} db info")),
+		menu.WithPreview(d.App.PreviewCmd("{1}", "db info")),
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- fixes #62
- revert: 6482509 refactor(cmd/root): centralize `flags`
