### PR TITLE
fix(pager): restore terminal `state` after pager is `interrupted`

### DIFF
--- a/internal/sys/terminal/term.go
+++ b/internal/sys/terminal/term.go
@@ -410,18 +410,16 @@ func (t *Term) paginate(ctx context.Context, content string) error {
 	if pager == "" {
 		pager = "less"
 	}
-
 	args := strings.Fields(pager)
-	exe := args[0]
 
 	//nolint:gosec // false positive: we explicitly want to allow the user to
 	// define their own PAGER command
-	cmd := exec.CommandContext(ctx, exe, args[1:]...)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Stdin = strings.NewReader(content)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if err := cmd.Run(); err != nil {
+	if err := withRestoredTerminal(cmd.Run); err != nil {
 		_, err = fmt.Fprint(t.writer, content)
 		return err
 	}

--- a/internal/sys/terminal/terminal.go
+++ b/internal/sys/terminal/terminal.go
@@ -157,3 +157,23 @@ func init() {
 func NonInteractiveMode(b bool) {
 	force = b
 }
+
+// withRestoredTerminal saves the terminal state, runs fn, then restores it
+// regardless of how fn exits. Safe to call even if stdin is not a terminal.
+func withRestoredTerminal(fn func() error) error {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return fn()
+	}
+	saved, err := term.GetState(fd)
+	if err != nil {
+		slog.Debug("failed to save terminal state", "err", err)
+		return fn()
+	}
+	defer func() {
+		if err := term.Restore(fd, saved); err != nil {
+			slog.Debug("failed to restore terminal state", "err", err)
+		}
+	}()
+	return fn()
+}


### PR DESCRIPTION
- when `ctrl-c` is pressed while `less` is running, the process is killed
before it can restore the terminal settings it modified, leaving the
terminal in a broken state where typed characters are not echoed and
control sequences appear as raw text (e.g. `^P`, `^N`).

- Snapshot the terminal state now is purely local
