### PR TITLE
feat/128 gpg expired key

### DIFF
--- a/internal/gitops/actions.go
+++ b/internal/gitops/actions.go
@@ -39,12 +39,16 @@ func addFiles(ctx context.Context, repoPath string, bs []*bookmark.Bookmark) err
 	if gpg.IsInitialized(root) {
 		fingerprintPath := gpg.GPGIDPath(root)
 
-		recipient, err := gpg.LoadFingerprint(fingerprintPath)
+		fp, err := gpg.LookupKey(fingerprintPath)
 		if err != nil {
 			return fmt.Errorf("gpg strategy: %w", err)
 		}
 
-		g, err := gpg.New(recipient)
+		if err := fp.Validate(); err != nil {
+			return err
+		}
+
+		g, err := gpg.New(fp.Fingerprint)
 		if err != nil {
 			return err
 		}

--- a/internal/gitops/gpg.go
+++ b/internal/gitops/gpg.go
@@ -16,12 +16,7 @@ import (
 	"github.com/mateconpizza/gm/pkg/git"
 )
 
-func gpgStrategy(fingerprintPath string) (*bookio.RepositoryLoader, error) {
-	recipient, err := gpg.LoadFingerprint(fingerprintPath)
-	if err != nil {
-		return nil, fmt.Errorf("gpg strategy: %w", err)
-	}
-
+func gpgStrategy(recipient string) (*bookio.RepositoryLoader, error) {
 	g, err := gpg.New(recipient)
 	if err != nil {
 		return nil, err

--- a/internal/handler/gpg.go
+++ b/internal/handler/gpg.go
@@ -74,6 +74,7 @@ func menuFingerprint(c *ui.Console, app *application.App) *menu.Menu[*gpg.Finger
 		menu.WithMultilineView(),
 		menu.WithPreview(gpg.Command+" --list-keys {+4}"),
 	)
+
 	m.SetFormatter(func(f **gpg.Fingerprint) string {
 		fp := *f
 		return fmt.Sprintf(
@@ -103,8 +104,8 @@ func selectFingerprint(m *menu.Menu[*gpg.Fingerprint], fps []*gpg.Fingerprint) (
 }
 
 func initGPG(ctx context.Context, c *ui.Console, m *git.Mgr, k *gpg.Fingerprint) error {
-	if !k.IsTrusted() {
-		return fmt.Errorf("%w: %s", gpg.ErrKeyNotTrusted, k.UserID)
+	if err := k.Validate(); err != nil {
+		return fmt.Errorf("gpg init: %w", err)
 	}
 
 	if err := gpg.Init(m.Root(), git.AttributesFile, k); err != nil {

--- a/internal/locker/gpg/fingerprint.go
+++ b/internal/locker/gpg/fingerprint.go
@@ -3,11 +3,30 @@ package gpg
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
+)
+
+var (
+	ErrKeyExpired    = errors.New("gpg: key has expired")
+	ErrKeyNotFound   = errors.New("gpg: key not found")
+	ErrKeyNotTrusted = errors.New("gpg: key not trusted")
+	ErrKeyUnusable   = errors.New("gpg: unusable public key")
+)
+
+type TrustLevel string
+
+const (
+	TrustUltimate TrustLevel = "u"
+	TrustFull     TrustLevel = "f"
+	TrustMarginal TrustLevel = "m"
+	TrustExpired  TrustLevel = "e"
+	TrustNever    TrustLevel = "n"
+	TrustUnknown  TrustLevel = "q" // also “o”, “-”, or empty string.
 )
 
 // Fingerprint represents a GPG key and its subkeys.
@@ -18,26 +37,26 @@ type Fingerprint struct {
 	Subkeys      []string // list of subkey fingerprints
 	SubkeyIDs    []string // list of subkey short IDs
 	IsPrimaryKey bool
-	TrustLevel   string
+	TrustLevel   TrustLevel
 }
 
 // IsTrusted returns true if the key is fully or ultimately trusted.
 func (f *Fingerprint) IsTrusted() bool {
-	return f.TrustLevel == "f" || f.TrustLevel == "u"
+	return f.TrustLevel == TrustFull || f.TrustLevel == TrustUltimate
 }
 
 // TrustLevelString returns a human-readable trust level.
 func (f *Fingerprint) TrustLevelString() string {
 	switch f.TrustLevel {
-	case "u":
+	case TrustUltimate:
 		return "ultimate"
-	case "f":
+	case TrustFull:
 		return "full"
-	case "m":
+	case TrustMarginal:
 		return "marginal"
-	case "n":
+	case TrustNever:
 		return "never"
-	case "q", "o", "-", "":
+	case TrustUnknown, "o", "-", "":
 		return "unknown"
 	default:
 		return "unknown"
@@ -165,7 +184,7 @@ func parseGPGOutput(output []byte) ([]*Fingerprint, error) {
 func handlePub(fields []string, trustIdx, keyIdx int) *Fingerprint {
 	return &Fingerprint{
 		KeyID:        fields[keyIdx],
-		TrustLevel:   fields[trustIdx],
+		TrustLevel:   TrustLevel(fields[trustIdx]),
 		IsPrimaryKey: true,
 	}
 }

--- a/internal/locker/gpg/fingerprint.go
+++ b/internal/locker/gpg/fingerprint.go
@@ -45,6 +45,10 @@ func (f *Fingerprint) IsTrusted() bool {
 	return f.TrustLevel == TrustFull || f.TrustLevel == TrustUltimate
 }
 
+func (f *Fingerprint) Expired() bool {
+	return f.TrustLevel == TrustExpired
+}
+
 // TrustLevelString returns a human-readable trust level.
 func (f *Fingerprint) TrustLevelString() string {
 	switch f.TrustLevel {
@@ -52,6 +56,8 @@ func (f *Fingerprint) TrustLevelString() string {
 		return "ultimate"
 	case TrustFull:
 		return "full"
+	case TrustExpired:
+		return "expired"
 	case TrustMarginal:
 		return "marginal"
 	case TrustNever:

--- a/internal/locker/gpg/fingerprint.go
+++ b/internal/locker/gpg/fingerprint.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -69,8 +68,51 @@ func (f *Fingerprint) TrustLevelString() string {
 	}
 }
 
+func (f *Fingerprint) Validate() error {
+	if f.Expired() {
+		return fmt.Errorf("%w: %s %q", ErrKeyExpired, f.UserID, f.Fingerprint)
+	}
+	if f.IsTrusted() {
+		return fmt.Errorf("%w: %s %q", ErrKeyNotTrusted, f.UserID, f.Fingerprint)
+	}
+	return nil
+}
+
 func (f *Fingerprint) String() string {
 	return fmt.Sprintf("ID: %s  User: %s\nFingerprint: %s", f.KeyID, f.UserID, f.Fingerprint)
+}
+
+// LookupKey looks up the GPG key for the fingerprint stored in path.
+func LookupKey(path string) (*Fingerprint, error) {
+	if !fileExists(path) {
+		return nil, fmt.Errorf("%w: %q", os.ErrNotExist, path)
+	}
+
+	recipient, err := loadFingerprint(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if recipient == "" {
+		return nil, ErrNoGPGRecipient
+	}
+
+	fps, err := ListFingerprints()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(fps) == 0 {
+		return nil, ErrNoFingerprint
+	}
+
+	for i := range fps {
+		if fps[i].Fingerprint == recipient {
+			return fps[i], nil
+		}
+	}
+
+	return nil, ErrNoFingerprint
 }
 
 // ListFingerprints lists all public GPG keys with their fingerprints and subkeys.
@@ -92,30 +134,21 @@ func ListFingerprints() ([]*Fingerprint, error) {
 	return fps, nil
 }
 
-// LoadFingerprint loads fingerprint from the .gpg-id file.
-func LoadFingerprint(f string) (string, error) {
+// loadFingerprint loads fingerprint from the .gpg-id file.
+func loadFingerprint(f string) (string, error) {
 	if !fileExists(f) {
-		slog.Debug("gpg: gpg-id file does not exist", "path", f)
 		return "", fmt.Errorf("%w: %q", ErrNoGPGIDFile, f)
 	}
 
 	fingerprint, err := os.ReadFile(f)
 	if err != nil {
-		slog.Debug("gpg: failed to read gpg-id file", "path", f, "error", err)
 		return "", fmt.Errorf("failed to read .gpg-id: %w", err)
 	}
 
 	recipientKey := strings.TrimSpace(string(fingerprint))
 	if recipientKey == "" {
-		slog.Debug("gpg: empty fingerprint in gpg-id file", "path", f)
 		return "", ErrNoFingerprint
 	}
-
-	slog.Debug(
-		"gpg: loaded GPG fingerprint successfully",
-		"path", f,
-		"fingerprint", recipientKey,
-	)
 
 	return recipientKey, nil
 }

--- a/internal/locker/gpg/gpg.go
+++ b/internal/locker/gpg/gpg.go
@@ -53,13 +53,18 @@ func (g *GPG) Decrypt(ctx context.Context, encryptedPath string) ([]byte, error)
 
 	slog.Debug("gpg: executing GPG command", "args", cmd.Args)
 
-	output, err := cmd.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
 	if err != nil {
-		msg := strings.TrimSpace(string(output))
-		slog.Debug("gpg: decryption failed", "error", err, "output", msg, "output_length", len(output))
-		return nil, fmt.Errorf("gpg decrypt failed: %s: %w", msg, err)
+		return nil, fmt.Errorf("gpg decrypt failed: %w: %s", err, stderr.String())
 	}
 
+	output := stdout.Bytes()
 	slog.Info("gpg: decryption successful", "encrypted_path", encryptedPath, "output_size", len(output))
 
 	return output, nil
@@ -85,15 +90,20 @@ func (g *GPG) Encrypt(ctx context.Context, path string, content []byte) error {
 
 	slog.Debug("gpg: executing GPG command", "args", cmd.Args)
 
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	cmd.Stdin = bytes.NewReader(content)
 
-	output, err := cmd.CombinedOutput()
+	err := cmd.Run()
 	if err != nil {
-		slog.Debug("gpg: encryption failed", "error", err, "output_length", len(output))
-		return fmt.Errorf("gpg encrypt failed: %s: %w", strings.TrimSpace(string(output)), err)
+		if strings.Contains(stderr.String(), "Unusable public key") {
+			return fmt.Errorf("%w: %q", ErrKeyUnusable, g.recipient)
+		}
+
+		return fmt.Errorf("gpg encrypt failed: %w: %s", err, stderr.String())
 	}
 
-	slog.Info("gpg: encryption successful", "encrypted_path", path, "output_size", len(output))
+	slog.Info("gpg: encryption successful", "encrypted_path", path)
 
 	return nil
 }

--- a/internal/locker/gpg/gpg.go
+++ b/internal/locker/gpg/gpg.go
@@ -16,7 +16,6 @@ import (
 )
 
 var (
-	ErrKeyNotTrusted  = errors.New("gpg: key is not trusted")
 	ErrNoFingerprint  = errors.New("gpg: no fingerprint found")
 	ErrNoGPGIDFile    = errors.New("gpg: no .gpg-id file found")
 	ErrNoGPGRecipient = errors.New("gpg: no GPG recipient configured")

--- a/internal/locker/gpg/gpg.go
+++ b/internal/locker/gpg/gpg.go
@@ -146,7 +146,7 @@ func New(recipient string) (*GPG, error) {
 // IsInitialized returns true if GPG is active.
 func IsInitialized(path string) bool {
 	f := GPGIDPath(path)
-	recipientKey, err := LoadFingerprint(f)
+	recipientKey, err := loadFingerprint(f)
 	if err != nil {
 		return false
 	}
@@ -167,7 +167,7 @@ func Unlocked(ctx context.Context, filePath string) (bool, error) {
 
 // Decrypt decrypts the provided encrypted file.
 func Decrypt(ctx context.Context, fingerprintPath, encryptedPath string) ([]byte, error) {
-	recipientKey, err := LoadFingerprint(fingerprintPath)
+	recipientKey, err := loadFingerprint(fingerprintPath)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func Decrypt(ctx context.Context, fingerprintPath, encryptedPath string) ([]byte
 
 // Encrypt encrypts the provided data and saves it to the specified path.
 func Encrypt(ctx context.Context, fingerprintPath, path string, content []byte) error {
-	recipientKey, err := LoadFingerprint(fingerprintPath)
+	recipientKey, err := loadFingerprint(fingerprintPath)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func Init(path, gitAttrFile string, fingerprint *Fingerprint) error {
 
 // GPGIDPath returns the path to the .gpg-id file inside the given repo directory.
 func GPGIDPath(repoPath string) string {
-	return filepath.Join(repoPath, ".gpg-id")
+	return filepath.Join(repoPath, fingerprintIDFilename)
 }
 
 func which() (string, error) {

--- a/internal/locker/gpg/gpg_test.go
+++ b/internal/locker/gpg/gpg_test.go
@@ -81,7 +81,7 @@ func TestFingerprintTrust(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name       string
-		trustLevel string
+		trustLevel TrustLevel
 		wantTrust  bool
 		wantString string
 	}{

--- a/internal/locker/gpg/gpg_test.go
+++ b/internal/locker/gpg/gpg_test.go
@@ -117,7 +117,7 @@ func TestLoadFingerprint(t *testing.T) {
 	gpgIDPath := filepath.Join(tmpDir, fingerprintIDFilename)
 
 	// Test: file doesn't exist
-	_, err := LoadFingerprint(gpgIDPath)
+	_, err := loadFingerprint(gpgIDPath)
 	if err == nil {
 		t.Error("expected error when file doesn't exist")
 	}
@@ -126,7 +126,7 @@ func TestLoadFingerprint(t *testing.T) {
 	if err := os.WriteFile(gpgIDPath, []byte(""), filePerm); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
-	_, err = LoadFingerprint(gpgIDPath)
+	_, err = loadFingerprint(gpgIDPath)
 	if !errors.Is(err, ErrNoFingerprint) {
 		t.Errorf("expected ErrNoFingerprint, got %v", err)
 	}
@@ -136,7 +136,7 @@ func TestLoadFingerprint(t *testing.T) {
 	if err := os.WriteFile(gpgIDPath, []byte(testFingerprint+"\n"), filePerm); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
-	fp, err := LoadFingerprint(gpgIDPath)
+	fp, err := loadFingerprint(gpgIDPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestLoadFingerprint(t *testing.T) {
 	if err := os.WriteFile(gpgIDPath, []byte("  "+testFingerprint+"  \n"), filePerm); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}
-	fp, err = LoadFingerprint(gpgIDPath)
+	fp, err = loadFingerprint(gpgIDPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/locker/gpg/gpg_test.go
+++ b/internal/locker/gpg/gpg_test.go
@@ -294,7 +294,7 @@ func TestGPG_Encrypt_CommandFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from Encrypt, got nil")
 	}
-	if !strings.Contains(err.Error(), "gpg encrypt failed") {
+	if !strings.Contains(err.Error(), "gpg encrypt failed:") {
 		t.Errorf("unexpected error message: %v", err)
 	}
 }


### PR DESCRIPTION
- **refactor(gpg): add `typed` trust levels**
- **feat(gpg): add key `Expired()` method**
- **refactor(gpg): replace fingerprint loading with key lookup**
- **refactor(gpg): improve gpg command `error` handling**

fixes #128
